### PR TITLE
Issue #1376018 by Anandyrh: D7 Quick Tabs Mouse Hover

### DIFF
--- a/js/quicktabs.js
+++ b/js/quicktabs.js
@@ -34,11 +34,38 @@ Drupal.quicktabs.prepare = function(el) {
       $(element).addClass('quicktabs-loaded');
       $(element).append('<span id="active-quicktabs-tab" class="element-invisible">' + Drupal.t('(active tab)') + '</span>');
     }
-    $(element).once(function() {$(this).bind('click', {tab: tab}, Drupal.quicktabs.clickHandler);});
+    
+	if($('#quicktabs-' + qt_name).hasClass('quicktabs_hover')) {
+		$(element).once(function() {$(this).bind('mouseenter', {tab: tab}, Drupal.quicktabs.hoverHandler);});
+	} else {
+		$(element).once(function() {$(this).bind('click', {tab: tab}, Drupal.quicktabs.clickHandler);});
+	}
   });
 }
 
 Drupal.quicktabs.clickHandler = function(event) {
+  var tab = event.data.tab;
+  var element = this;
+  // Set clicked tab to active.
+  $(this).parents('li').siblings().removeClass('active');
+  $(this).parents('li').addClass('active');
+
+  $("ul.quicktabs-tabs li a span#active-quicktabs-tab").remove();
+  $(this).append('<span id="active-quicktabs-tab" class="element-invisible">' + Drupal.t('(active tab)') + '</span>');
+
+  // Hide all tabpages.
+  tab.container.children().addClass('quicktabs-hide');
+  
+  if (!tab.tabpage.hasClass("quicktabs-tabpage")) {
+    tab = new Drupal.quicktabs.tab(element);
+  }
+
+  tab.tabpage.removeClass('quicktabs-hide');
+  $(element).trigger('switchtab');
+  return false;
+}
+
+Drupal.quicktabs.hoverHandler = function(event) {
   var tab = event.data.tab;
   var element = this;
   // Set clicked tab to active.

--- a/plugins/QuickQuicktabs.inc
+++ b/plugins/QuickQuicktabs.inc
@@ -23,7 +23,7 @@ class QuickQuicktabs extends QuickRenderer {
         '#theme' => 'qt_quicktabs',
         '#options' => array('attributes' => array(
           'id' => 'quicktabs-' . $qt_name,
-          'class' => 'quicktabs-wrapper quicktabs-style-' . drupal_html_class($settings['style']),
+          'class' => 'quicktabs-wrapper quicktabs-style-' . drupal_html_class($settings['style']) . (($settings['use_hover']) ? ' quicktabs_hover' : ''),
         )),
         'tabs' => array('#theme' => 'qt_quicktabs_tabset', '#options' => array('active' => $active_tab, 'style' => drupal_html_class($settings['style'])), 'tablinks' => $tabs),
         // The main content area, each quicktab container needs a unique id.

--- a/quicktabs.admin.inc
+++ b/quicktabs.admin.inc
@@ -218,6 +218,15 @@ function _quicktabs_admin_main_form($form_state, &$qt) {
     );
   }
 
+  $form['use_hover'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable on hover'),
+    '#default_value' => isset($qt->use_hover) ? $qt->use_hover : 0,
+    '#description' => t('Enable tab on mouse over and not on click.'),
+    '#states' => array('visible' => array(':input[name="renderer"]' => array('value' => 'quicktabs'))),
+    '#weight' => -5,
+  );
+
   $form['ajax'] = array(
     '#type' => 'radios',
     '#title' => t('Ajax'),
@@ -644,6 +653,7 @@ function _quicktabs_convert_form_to_quicktabs($form_state) {
   $qt->ajax = $form_state['values']['ajax'];
   $qt->default_tab = isset($form_state['values']['default_tab']) ? $form_state['values']['default_tab'] : 0;
   $qt->hide_empty_tabs = $form_state['values']['hide_empty_tabs'];
+  $qt->use_hover = $form_state['values']['use_hover'];
   $qt->renderer = $renderer;
   $qt->style = $form_state['values']['style'];
   $qt->tabs = $formvalues_tabs;

--- a/quicktabs.install
+++ b/quicktabs.install
@@ -45,6 +45,14 @@ function quicktabs_schema() {
         'not null' => TRUE,
         'default' => 0,
       ),
+      'use_hover' => array(
+        'description' => 'Whether this tabset has tabs enabled on mouse over.',
+        'type' => 'int',
+        'size' => 'tiny',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ),
       'default_tab' => array(
         'description' => 'Default tab.',
         'type' => 'int',
@@ -209,4 +217,31 @@ function quicktabs_update_7303() {
     }
   }
   return 'Added support for view modes.';
+}
+
+/**
+ * Add the table field where the checkbox to enable tabs on mouse over and not on click is stored
+ */
+function quicktabs_update_7304() {
+  if (!db_field_exists('quicktabs', 'use_hover')) {
+    db_drop_primary_key('quicktabs');
+    $output[] = "Drop the primary key";
+	
+    // Add the use_hover field
+    $use_hover_field = array(
+        'description' => 'Whether this tabset has tabs enabled on mouse over.',
+        'type' => 'int',
+        'size' => 'tiny',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+    );
+    db_add_field('quicktabs', 'use_hover', $use_hover_field);
+    $output[] = "Added the use_hover field";
+    
+	db_add_primary_key('quicktabs', array('machine_name'));
+    $output[] = "Add the primary key back!";
+  }
+  
+  return implode('<br />', $output);
 }


### PR DESCRIPTION
Added a checkbox in the quicktab config screen, which is only available if the "quicktabs" renderer is selected.
Added a new field in quicktabs table by a new update procedure
Added some javascript code in the behaviour to check if the user wants the tabs to use change on hover or on click